### PR TITLE
Add shortCircuit on gog catalog, for games without final price

### DIFF
--- a/apiHandle.js
+++ b/apiHandle.js
@@ -46,7 +46,7 @@ async function getGOGGames() {
 const filterGOGGames = (data) => {
 	const games = data.products;
 	const filteredGames = games.filter(
-		(game) => game.price.finalMoney.amount == 0
+		(game) => game.price?.finalMoney.amount == 0
 	);
 	const response = filteredGames.map((game) => ({
 		url: game.storeLink,


### PR DESCRIPTION
Some gog games didn't have a finalMoney field and that was breaking the rest of the code.

I also noticed that some of the results are not accurate with current, https://www.gamerpower.com/api/giveaways?platform=pc&type=game this API endpoint would be valuable to get more free games with better results.